### PR TITLE
Limit MACOSX_DEPLOYMENT_TARGET based on Python.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,6 +1,10 @@
-# If MACOSX_DEPLOYMENT_TARGET is not set, we force it to be at least 10.9
-# (Mavericks). This is the earliest version of OS X expected to work with
-# release 11 of the LSST stack.
+# If MACOSX_DEPLOYMENT_TARGET is not set, we force it to correspond to the
+# greater of 10.9 or the target used when compiling Python.
 # This works around DM-5409, wherein mpi4py was attempting to use an OS X 10.5
-# SDK, based on querying Anaconda, and failing.
-export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.9}
+# SDK, based on querying Anaconda, and failing; and DM-6133, wherein distutils
+# refuses to let us target an earlier SDK than Python was compiled with.
+if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
+    MIN_DEPLOYMENT_TARGET=9
+    CFG_DEPLOYMENT_TARGET=$(python -c "import sysconfig; print((sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') or '10.$MIN_DEPLOYMENT_TARGET').split('.')[1])")
+    export MACOSX_DEPLOYMENT_TARGET=10.$((MIN_DEPLOYMENT_TARGET>CFG_DEPLOYMENT_TARGET?MIN_DEPLOYMENT_TARGET:CFG_DEPLOYMENT_TARGET))
+fi


### PR DESCRIPTION
It's not possible to compile Python extensions targeting an earlier SDK than
Python itself was compiled for. Conversely, we don't want to target a later
version of the SDK than is available on the current platform. Finally, the
stack itself requires at least OSX 10.9.

Here, we attempt to be smart about choosing an SDK version that satisfies all
the above constraints.
